### PR TITLE
feat: add login context helper to playwright

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -35,7 +35,7 @@ import { type CheerioRoot, type Dictionary, expandShadowRoots, sleep } from '@cr
 import * as cheerio from 'cheerio';
 import { getInjectableScript as getCookieClosingScript } from 'idcac-playwright';
 import ow from 'ow';
-import type { Page, Response, Route } from 'playwright';
+import type { Locator, Page, Response, Route } from 'playwright';
 
 import { LruCache } from '@apify/datastructures';
 import log_ from '@apify/log';
@@ -662,6 +662,336 @@ export async function closeCookieModals(page: Page): Promise<void> {
     await page.evaluate(getCookieClosingScript());
 }
 
+export interface LoginOptions {
+    /**
+     * The username/email for login.
+     */
+    username: string;
+
+    /**
+     * The password for login.
+     */
+    password: string;
+
+    /**
+     * Optional custom locators getters for login form elements.
+     * If not provided, default locators will be used.
+     */
+    locators?: {
+        /**
+         * Returns locators for the username/email input field.
+         */
+        getUsernameInput?: (page: Page) => Locator;
+
+        /**
+         * Returns locators for the password input field.
+         */
+        getPasswordInput?: (page: Page) => Locator;
+
+        /**
+         * Returns locators for the submit button.
+         */
+        getSubmitButton?: (page: Page) => Locator;
+
+        /**
+         * Returns locators for the "Next" button in two-step login forms.
+         */
+        getNextButton?: (page: Page) => Locator;
+    };
+
+    /**
+     * Optional custom function to detect if login succeeded.
+     * If not provided, a default heuristic will be used.
+     * @param page The Playwright page
+     * @returns Promise that resolves to true if login succeeded, false otherwise
+     */
+    detectLoginSuccess?: (page: Page) => Promise<boolean>;
+
+    /**
+     * Timeout for login operations in milliseconds.
+     * @default 10_000
+     */
+    timeoutMs?: number;
+}
+
+/**
+ * Attempts to log in to a website using the provided credentials.
+ *
+ * This function can handle both single-step and two-step login forms.
+ * It will automatically detect the type of login form and attempt to fill it out.
+ *
+ * @param page The Playwright page
+ * @param options Login options including username, password, and optional configurations
+ * @returns Promise that resolves when login is complete
+ * @throws Error if login fails or login form is not detected
+ */
+export async function login(page: Page, options: LoginOptions): Promise<void> {
+    ow(page, ow.object.validate(validators.browserPage));
+    ow(
+        options,
+        ow.object.exactShape({
+            username: ow.string.nonEmpty,
+            password: ow.string.nonEmpty,
+            detectLoginForm: ow.optional.function,
+            detectLoginSuccess: ow.optional.function,
+            timeoutMs: ow.optional.number.positive,
+            locators: ow.optional.object,
+        }),
+    );
+
+    const {
+        username,
+        password,
+        timeoutMs = 10_000,
+        detectLoginSuccess = getDefaultDetectLoginSuccess({ timeoutMs, page }),
+        locators = {},
+    } = options;
+
+    // Merge custom locators with defaults
+    const finalLocators = {
+        usernameInput:
+            locators.getUsernameInput?.(page) ??
+            [
+                page.locator('input[name="username"]'),
+                page.locator('input[name="email"]'),
+                page.locator('input[name="user"]'),
+                page.locator('input[name="login"]'),
+                page.locator('input[type="email"]'),
+                page.locator('input[id*="username"]'),
+                page.locator('input[id*="email"]'),
+                page.locator('input[id*="login"]'),
+                page.locator('input[placeholder*="username" i]'),
+                page.locator('input[placeholder*="email" i]'),
+                page.locator('input[placeholder*="user" i]'),
+                page.locator('input[aria-label*="username" i]'),
+                page.locator('input[aria-label*="email" i]'),
+                page.locator('input[class*="username"]'),
+                page.locator('input[class*="email"]'),
+                page.locator('input[class*="user"]'),
+            ].reduce((acc, locator) => acc.or(locator), page.locator('input[class*="login"]')),
+        passwordInput:
+            locators.getPasswordInput?.(page) ??
+            [
+                page.locator('input[name="password"]'),
+                page.locator('input[type="password"]'),
+                page.locator('input[id*="password"]'),
+                page.locator('input[placeholder*="password" i]'),
+                page.locator('input[aria-label*="password" i]'),
+            ].reduce((acc, locator) => acc.or(locator), page.locator('input[class*="password"]')),
+        submitButton:
+            locators.getSubmitButton?.(page) ??
+            [
+                page.locator('button[type="submit"]'),
+                page.locator('input[type="submit"]'),
+                page.locator('button[name="submit"]'),
+                page.locator('button[id*="submit"]'),
+                page.locator('button[id*="login"]'),
+                page.locator('button[id*="signin"]'),
+                page.locator('button[class*="submit"]'),
+                page.locator('button[class*="login"]'),
+                page.locator('button[class*="signin"]'),
+                page.locator('button:has-text("Log in")'),
+                page.locator('button:has-text("Sign in")'),
+                page.locator('button:has-text("Login")'),
+                page.locator('button:has-text("Submit")'),
+                page.locator('a[role="button"]:has-text("Log in")'),
+                page.locator('a[role="button"]:has-text("Sign in")'),
+            ].reduce((acc, locator) => acc.or(locator), page.locator('a[role="button"]:has-text("Login")')),
+        nextButton:
+            locators.getNextButton?.(page) ??
+            [
+                page.locator('button:has-text("Next")'),
+                page.locator('button:has-text("Continue")'),
+                page.locator('button[id*="next"]'),
+                page.locator('button[class*="next"]'),
+                page.locator('button[class*="continue"]'),
+                page.locator('input[type="submit"][value*="Next"]'),
+            ].reduce((acc, locator) => acc.or(locator), page.locator('input[type="submit"][value*="Continue"]')),
+    };
+
+    // Check if username input is present
+    await finalLocators.usernameInput.first().waitFor({ timeout: timeoutMs });
+    const hasUsernameInput = await finalLocators.usernameInput
+        .first()
+        .isVisible()
+        .catch(() => false);
+    if (!hasUsernameInput) {
+        // No username input detected, assume already logged in or not needed
+        return;
+    }
+
+    // Check if password field is immediately visible (single-step login)
+    const passwordInputVisible = await finalLocators.passwordInput
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+    if (passwordInputVisible) {
+        // Single-step login form
+        await performSingleStepLogin({ page, username, password, locators: finalLocators, timeoutMs });
+    } else {
+        // Two-step login form
+        await performTwoStepLogin({ page, username, password, locators: finalLocators, timeoutMs });
+    }
+
+    // Check if login was successful
+    const loginSuccessful = await detectLoginSuccess(page);
+    if (!loginSuccessful) {
+        throw new Error('Login failed - success detection heuristic indicates login was not successful');
+    }
+}
+
+/**
+ * Default heuristic to detect if login was successful.
+ */
+function getDefaultDetectLoginSuccess({ timeoutMs, page }: { timeoutMs: number; page: Page }): () => Promise<boolean> {
+    return async () => {
+        try {
+            const indicators = {
+                failure: [
+                    page.getByText('Invalid credentials'),
+                    page.getByText('Invalid username or password'),
+                    page.getByText('Login failed'),
+                    page.getByText('Authentication failed'),
+                    page.getByText('Incorrect username or password'),
+                    page.getByText('Wrong username or password'),
+                    page.locator('[class*="error"]'),
+                    page.locator('[class*="alert"]'),
+                    page.locator('[role="alert"]'),
+                    page.locator('.login-error'),
+                    page.locator('.error-message'),
+                    page.locator('#error'),
+                ].reduce((acc, locator) => acc.or(locator), page.locator('.failure')),
+                success: [
+                    page.getByText('Welcome'),
+                    page.getByText('Dashboard'),
+                    page.getByText('Profile'),
+                    page.getByText('Account'),
+                    page.getByText('Logout'),
+                    page.getByText('Sign out'),
+                    page.locator('a[href*="logout"]'),
+                    page.locator('a[href*="signout"]'),
+                    page.locator('button:has-text("Logout")'),
+                    page.locator('button:has-text("Sign out")'),
+                    page.locator('[class*="dashboard"]'),
+                    page.locator('[class*="profile"]'),
+                    page.locator('[class*="account"]'),
+                    page.locator('[data-testid*="user-menu"]'),
+                ].reduce((acc, locator) => acc.or(locator), page.locator('[data-testid*="profile"]')),
+            };
+
+            // Check visibility of any of the indicators
+            const indicatorPromises = Object.entries(indicators).map(async ([key, locator]) => {
+                const locatorFirst = locator.first();
+                await locatorFirst.waitFor({ timeout: timeoutMs });
+                return { type: key as keyof typeof indicators, visible: await locatorFirst.isVisible() };
+            });
+
+            try {
+                // Wait for first indicator to be resolved
+                const visibleIndicator = await Promise.any(indicatorPromises);
+                if (visibleIndicator.visible) {
+                    if (visibleIndicator.type === 'failure') {
+                        return false;
+                    }
+                    return true;
+                }
+            } catch {
+                // continue to next indicator
+            }
+
+            // Check if we're no longer on a login page
+            const currentUrl = page.url();
+            const isLoginPage = /login|signin|auth|sign-in/i.test(currentUrl);
+
+            // If we're not on a login page and no failure indicators, assume success
+            return !isLoginPage;
+        } catch (error) {
+            // If we can't determine success, assume failure for safety
+            return false;
+        }
+    };
+}
+
+/**
+ * Performs single-step login (username and password on same form).
+ */
+async function performSingleStepLogin({
+    page,
+    username,
+    password,
+    locators,
+    timeoutMs = 30_000,
+}: {
+    page: Page;
+    username: string;
+    password: string;
+    locators: { usernameInput: Locator; passwordInput: Locator; submitButton: Locator; nextButton: Locator };
+    timeoutMs: number;
+}): Promise<void> {
+    // Fill username
+    const usernameField = locators.usernameInput.first();
+    await usernameField.waitFor({ timeout: timeoutMs });
+    await usernameField.fill(username);
+
+    // Fill password
+    const passwordField = locators.passwordInput.first();
+    await passwordField.waitFor({ timeout: timeoutMs });
+    await passwordField.fill(password);
+
+    // Submit form
+    const submitButton = locators.submitButton.first();
+    await submitButton.waitFor({ timeout: timeoutMs });
+    await submitButton.click();
+
+    // Wait for navigation or form submission
+    await page.waitForLoadState('networkidle', { timeout: timeoutMs }).catch(() => {
+        // Ignore timeout, continue with success detection
+    });
+}
+
+/**
+ * Performs two-step login (username first, then password).
+ */
+async function performTwoStepLogin({
+    page,
+    username,
+    password,
+    locators,
+    timeoutMs = 30_000,
+}: {
+    page: Page;
+    username: string;
+    password: string;
+    locators: { usernameInput: Locator; passwordInput: Locator; submitButton: Locator; nextButton: Locator };
+    timeoutMs: number;
+}): Promise<void> {
+    // Fill username
+    const usernameField = locators.usernameInput.first();
+    await usernameField.waitFor({ timeout: timeoutMs });
+    await usernameField.fill(username);
+
+    // Click next button
+    const nextButton = locators.nextButton.first();
+    await nextButton.waitFor({ timeout: timeoutMs });
+    await nextButton.click();
+
+    // Wait for password field to appear and fill it
+    const passwordField = locators.passwordInput.first();
+    await passwordField.waitFor({ timeout: timeoutMs });
+    await passwordField.fill(password);
+
+    // Submit form
+    const submitButton = locators.submitButton.first();
+    await submitButton.waitFor({ timeout: timeoutMs });
+    await submitButton.click();
+
+    // Wait for navigation or form submission
+    await page.waitForLoadState('networkidle', { timeout: timeoutMs }).catch(() => {
+        // Ignore timeout, continue with success detection
+    });
+}
+
 interface HandleCloudflareChallengeOptions {
     /** Logging defaults to the `debug` level, use this flag to log to `info` level instead. */
     verbose?: boolean;
@@ -1017,6 +1347,48 @@ export interface PlaywrightContextUtils {
      * @param [options]
      */
     handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<void>;
+
+    /**
+     * Attempts to log in to a website using the provided credentials.
+     *
+     * This function can handle both single-step and two-step login forms.
+     * It will automatically detect the type of login form and attempt to fill it out.
+     * If no login form is detected, the function will resolve without doing anything.
+     *
+     * **Example usage**
+     * ```ts
+     * async requestHandler({ login }) {
+     *     await login({
+     *         username: 'your-username',
+     *         password: 'your-password',
+     *     });
+     * }
+     * ```
+     *
+     * **Custom detection and handling**
+     * ```ts
+     * async requestHandler({ login }) {
+     *     await login({
+     *         username: 'your-username',
+     *         password: 'your-password',
+     *         locators: {
+     *             getUsernameInput: (page) => page.locator('#username'),
+     *             getPasswordInput: (page) => page.locator('#password'),
+     *             getSubmitButton: (page) => page.locator('#submit'),
+     *         },
+     *         detectLoginSuccess: async (page) => {
+     *             // Custom logic to detect successful login
+     *             return page.locator('.user-menu').isVisible();
+     *         },
+     *     });
+     * }
+     * ```
+     *
+     * @param options Login options including username, password, and optional configurations
+     * @returns Promise that resolves when login is complete
+     * @throws Error if login fails
+     */
+    login(options: LoginOptions): Promise<void>;
 }
 
 export function registerUtilsToContext(
@@ -1063,6 +1435,7 @@ export function registerUtilsToContext(
     context.handleCloudflareChallenge = async (options?: HandleCloudflareChallengeOptions) => {
         return handleCloudflareChallenge(context.page, context.request.url, context.session, options);
     };
+    context.login = async (options: LoginOptions) => login(context.page, options);
 }
 
 export { enqueueLinksByClickingElements };
@@ -1081,4 +1454,5 @@ export const playwrightUtils = {
     closeCookieModals,
     RenderingTypePredictor,
     handleCloudflareChallenge,
+    login,
 };

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -2,10 +2,11 @@ import type { Server } from 'node:http';
 import path from 'node:path';
 
 import { KeyValueStore, launchPlaywright, playwrightUtils, Request } from '@crawlee/playwright';
-import type { Browser, Page } from 'playwright';
+import type { Browser, Locator, Page } from 'playwright';
 import { chromium } from 'playwright';
 import { runExampleComServer } from 'test/shared/_helper';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
+import type { MockInstance } from 'vitest';
 
 import log from '@apify/log';
 
@@ -325,7 +326,7 @@ describe('playwrightUtils', () => {
             expect(before).toBe(false);
 
             await playwrightUtils.infiniteScroll(page, {
-                waitForSecs: Infinity,
+                waitForSecs: Number.POSITIVE_INFINITY,
                 maxScrollHeight: 1000,
                 stopScrollCallback: async () => true,
             });
@@ -342,7 +343,7 @@ describe('playwrightUtils', () => {
             expect(before).toBe(false);
 
             await playwrightUtils.infiniteScroll(page, {
-                waitForSecs: Infinity,
+                waitForSecs: Number.POSITIVE_INFINITY,
                 stopScrollCallback: async () => true,
             });
 
@@ -385,5 +386,357 @@ describe('playwrightUtils', () => {
         } finally {
             await browser.close();
         }
+    });
+
+    describe('login()', () => {
+        const getLocatorMock = () => {
+            const locatorMock = {
+                isVisible: vitest.fn().mockResolvedValue(true),
+                waitFor: vitest.fn(),
+                fill: vitest.fn(),
+                click: vitest.fn(),
+                first: vitest.fn(),
+                or: vitest.fn(),
+            };
+            locatorMock.first.mockReturnValue(locatorMock);
+            locatorMock.or.mockReturnValue(locatorMock);
+            return locatorMock;
+        };
+        type LocatorMock = ReturnType<typeof getLocatorMock>;
+
+        let browser: Browser = null as any;
+        beforeAll(async () => {
+            browser = await launchPlaywright(launchContext);
+        });
+        afterAll(async () => {
+            await browser.close();
+        });
+
+        let page: Page;
+        let newLocatorMock: LocatorMock;
+        let usernameInputMock: LocatorMock;
+        let passwordInputMock: LocatorMock;
+        let submitButtonMock: LocatorMock;
+        let nextButtonMock: LocatorMock;
+        beforeEach(async () => {
+            page = await browser.newPage();
+            newLocatorMock = getLocatorMock();
+            usernameInputMock = getLocatorMock();
+            passwordInputMock = getLocatorMock();
+            submitButtonMock = getLocatorMock();
+            nextButtonMock = getLocatorMock();
+            vitest.spyOn(page, 'locator').mockReturnValue(newLocatorMock as unknown as Locator);
+            vitest.spyOn(page, 'getByText').mockResolvedValue(newLocatorMock as unknown as Locator);
+        });
+        afterEach(async () => {
+            await page.close();
+        });
+
+        test('single-step login success', async () => {
+            const pageWaitForLoadStateSpy = vitest.spyOn(page, 'waitForLoadState').mockResolvedValue();
+
+            usernameInputMock.isVisible.mockResolvedValue(true);
+            // Password is visible in single-step flow
+            passwordInputMock.isVisible.mockResolvedValue(true);
+
+            const detectLoginSuccessMock = vitest.fn().mockResolvedValue(true);
+
+            await playwrightUtils.login(page, {
+                username: 'testuser',
+                password: 'testpass',
+                locators: {
+                    getUsernameInput: () => usernameInputMock as unknown as Locator,
+                    getPasswordInput: () => passwordInputMock as unknown as Locator,
+                    getSubmitButton: () => submitButtonMock as unknown as Locator,
+                },
+                detectLoginSuccess: detectLoginSuccessMock,
+            });
+
+            // Verify interactions
+            expect(usernameInputMock.fill).toHaveBeenCalledWith('testuser');
+            expect(passwordInputMock.fill).toHaveBeenCalledWith('testpass');
+            expect(submitButtonMock.click).toHaveBeenCalledTimes(1);
+            expect(pageWaitForLoadStateSpy).toHaveBeenCalledWith('networkidle', { timeout: 10_000 });
+            expect(detectLoginSuccessMock).toHaveBeenCalledWith(page);
+        });
+
+        test('single-step login failure', async () => {
+            usernameInputMock.isVisible.mockResolvedValue(true);
+            // Password is visible in single-step flow
+            passwordInputMock.isVisible.mockResolvedValue(true);
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                    detectLoginSuccess: async () => false,
+                }),
+            ).rejects.toThrow('Login failed - success detection heuristic indicates login was not successful');
+        });
+
+        test('two-step login success', async () => {
+            usernameInputMock.isVisible.mockResolvedValue(true);
+            // Password is not visible in two-step flow
+            passwordInputMock.isVisible.mockResolvedValue(false);
+
+            await playwrightUtils.login(page, {
+                username: 'testuser',
+                password: 'testpass',
+                locators: {
+                    getUsernameInput: () => usernameInputMock as unknown as Locator,
+                    getPasswordInput: () => passwordInputMock as unknown as Locator,
+                    getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    getNextButton: () => nextButtonMock as unknown as Locator,
+                },
+                detectLoginSuccess: async () => true,
+            });
+
+            // Verify interactions
+            expect(usernameInputMock.fill).toHaveBeenCalledWith('testuser');
+            expect(passwordInputMock.fill).toHaveBeenCalledWith('testpass');
+            expect(nextButtonMock.click).toHaveBeenCalledOnce();
+            expect(submitButtonMock.click).toHaveBeenCalledOnce();
+        });
+
+        test('two-step login failure', async () => {
+            usernameInputMock.isVisible.mockResolvedValue(true);
+            // Password is not visible in two-step flow
+            passwordInputMock.isVisible.mockResolvedValue(false);
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                        getNextButton: () => nextButtonMock as unknown as Locator,
+                    },
+                    detectLoginSuccess: async () => false,
+                }),
+            ).rejects.toThrow('Login failed - success detection heuristic indicates login was not successful');
+        });
+
+        test('no username input detected', async () => {
+            // Mock no username input detected
+            usernameInputMock.isVisible.mockResolvedValue(false);
+
+            // Should resolve without error when no username input is detected
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'testpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).resolves.toBeUndefined();
+
+            // Should not attempt to fill or click anything
+            expect(usernameInputMock.fill).not.toHaveBeenCalled();
+            expect(passwordInputMock.fill).not.toHaveBeenCalled();
+            expect(submitButtonMock.click).not.toHaveBeenCalled();
+        });
+
+        test('no password input detected', async () => {
+            // Mock no username input detected
+            passwordInputMock.fill.mockRejectedValue(new Error('Failed to fill password'));
+
+            // Should resolve without error when no username input is detected
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'testpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).rejects.toThrow('Failed to fill password');
+        });
+
+        test('default locators usage', async () => {
+            await playwrightUtils.login(page, {
+                username: 'testuser',
+                password: 'testpass',
+                detectLoginSuccess: async () => true,
+            });
+
+            // Verify custom selectors were used
+            expect(newLocatorMock.fill).toHaveBeenCalledWith('testuser');
+            expect(newLocatorMock.fill).toHaveBeenCalledWith('testpass');
+            expect(newLocatorMock.click).toHaveBeenCalled();
+            expect(newLocatorMock.or).toHaveBeenCalledTimes(42);
+        });
+
+        test('default detectLoginSuccess usage - failure indicator', async () => {
+            // Mock failed flow
+            newLocatorMock.isVisible.mockImplementation(async () => {
+                const callCount = newLocatorMock.isVisible.mock.calls.length;
+                if (callCount === 1) return true; // failure indicator visible
+
+                await new Promise((resolve) => setTimeout(resolve, 100));
+                return false; // no success indicator
+            });
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).rejects.toThrow('Login failed - success detection heuristic indicates login was not successful');
+            expect(newLocatorMock.or).toHaveBeenCalledTimes(32);
+        });
+
+        test('default detectLoginSuccess usage - success indicator', async () => {
+            // Mock successful flow
+            newLocatorMock.isVisible.mockImplementation(async () => {
+                const callCount = newLocatorMock.isVisible.mock.calls.length;
+                // no failure indicator
+                if (callCount === 1) {
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+                    return false;
+                }
+                // success indicator visible
+                return true;
+            });
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).resolves.toBeUndefined();
+            expect(newLocatorMock.or).toHaveBeenCalledTimes(32);
+        });
+
+        test('default detectLoginSuccess usage - path changed', async () => {
+            // Neither failure nor success indicator visible
+            newLocatorMock.isVisible.mockResolvedValue(false);
+            vitest.spyOn(page, 'url').mockResolvedValue('https://example.com/dashboard');
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).resolves.toBeUndefined();
+        });
+
+        test('default detectLoginSuccess usage - path is still login', async () => {
+            // Neither failure nor success indicator visible
+            newLocatorMock.isVisible.mockResolvedValue(false);
+            vitest.spyOn(page, 'url').mockReturnValue('https://example.com/login');
+
+            await expect(
+                playwrightUtils.login(page, {
+                    username: 'testuser',
+                    password: 'wrongpass',
+                    locators: {
+                        getUsernameInput: () => usernameInputMock as unknown as Locator,
+                        getPasswordInput: () => passwordInputMock as unknown as Locator,
+                        getSubmitButton: () => submitButtonMock as unknown as Locator,
+                    },
+                }),
+            ).rejects.toThrow('Login failed - success detection heuristic indicates login was not successful');
+        });
+
+        // TODO: remove this before merging, it's just for development, testing against 3rd party live website is not a good idea
+        test('live website login - SauceDemo', async () => {
+            vitest.spyOn(page, 'locator').mockRestore();
+            vitest.spyOn(page, 'getByText').mockRestore();
+
+            try {
+                // Navigate to SauceDemo - a popular demo site for testing automation
+                await page.goto('https://www.saucedemo.com/');
+
+                // Use the login function with known test credentials
+                await playwrightUtils.login(page, {
+                    username: 'standard_user',
+                    password: 'secret_sauce',
+                });
+
+                // Verify we successfully logged in by checking for the inventory page
+                const currentUrl = page.url();
+                expect(currentUrl).toContain('/inventory.html');
+
+                // Also verify the presence of the logout button which indicates successful login
+                // First open the menu to make the logout button visible
+                const menuButton = page.locator('[id="react-burger-menu-btn"]');
+                await menuButton.click();
+
+                const logoutButton = page.locator('[data-test="logout-sidebar-link"]');
+                await logoutButton.waitFor({ state: 'visible', timeout: 5000 });
+
+                // Verify we can see the products container
+                const productsContainer = page.locator('[data-test="inventory-container"]');
+                await productsContainer.waitFor({ state: 'visible', timeout: 5000 });
+            } catch (error: unknown) {
+                // If the test fails, it might be due to network issues or site changes
+                // Log the error but don't fail the entire test suite
+                console.warn('SauceDemo login test failed - this might be due to network issues:', error);
+                // Re-throw only if it's not a network-related error
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                if (errorMessage.includes('net::') || errorMessage.includes('timeout')) {
+                    console.warn('Skipping SauceDemo test due to network issues');
+                    return;
+                }
+                throw error;
+            }
+        });
+
+        // TODO: remove this before merging, it's just for development, testing against 3rd party live website is not a good idea
+        test('live website login failure - SauceDemo', async () => {
+            vitest.spyOn(page, 'locator').mockRestore();
+            vitest.spyOn(page, 'getByText').mockRestore();
+
+            try {
+                // Navigate to SauceDemo - a popular demo site for testing automation
+                await page.goto('https://www.saucedemo.com/');
+
+                await expect(() =>
+                    // Use the login function with bad credentials
+                    playwrightUtils.login(page, {
+                        username: 'standard_user',
+                        password: 'bad_password',
+                    }),
+                ).rejects.toThrowError('Login failed - success detection heuristic indicates login was not successful');
+            } catch (error: unknown) {
+                // If the test fails, it might be due to network issues or site changes
+                // Log the error but don't fail the entire test suite
+                console.warn('SauceDemo login test failed - this might be due to network issues:', error);
+                // Re-throw only if it's not a network-related error
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                if (errorMessage.includes('net::') || errorMessage.includes('timeout')) {
+                    console.warn('Skipping SauceDemo test due to network issues');
+                    return;
+                }
+                throw error;
+            }
+        });
     });
 });


### PR DESCRIPTION
Introduces a new `login()` utility function to the Playwright crawler that automatically handles website login forms.
The function handles one-step login forms, where both `username` and `password` inputs are visible at the same time, as well as two-step login forms, where the user has to click the "Next" button after filling in `username`.

Usage:
```typescript
async requestHandler({ login }) {
    await login({
        username: 'your-username',
        password: 'your-password',
        locators: {
            getUsernameInput: (page) => page.locator('#username'),
            getPasswordInput: (page) => page.locator('#password'),
            getSubmitButton: (page) => page.getByText('submit'),
        },
        detectLoginSuccess: async (page) => {
            return page.locator('.user-menu').isVisible();
        },
        timeoutMs: 15_000,
    });
}
```